### PR TITLE
[PKG-2459] python-kaleido 0.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  # kaleido-core=0.2.1 isn't available on s390x
+  skip: true  # [s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  # kaleido-core=0.2.1 isn't available on s390x
-  skip: true  # [s390x]
+  # kaleido-core=0.2.1 isn't available on s390x or ppc64le, see https://github.com/AnacondaRecipes/kaleido-core-feedstock/blob/d512c9bd10c86d252a6dfc3f0f9057e64ff92fba/recipe/meta.yaml#L26
+  skip: true  # [linux and (s390x or ppc64le)]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,22 +11,24 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.5
+    - python
     - kaleido-core ={{ version }}
 
 test:
+  # imports are inside run_test.py
   requires:
     - plotly >=4.10
-  imports:
-    - kaleido
+    - pip
 
 about:
   home: https://github.com/plotly/Kaleido

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,3 +1,8 @@
 from kaleido.scopes.plotly import PlotlyScope
+import subprocess
+
+
+subprocess.run(["pip", "check"], check=True)
+
 scope = PlotlyScope()
-assert scope.transform({"data": []}).startswith(b'\x89PNG')
+assert scope.transform({"data": []}).startswith(b"\x89PNG")


### PR DESCRIPTION
License: https://github.com/plotly/Kaleido/blob/v0.2.1/LICENSE.txt
Requirements: https://github.com/plotly/Kaleido/blob/v0.2.1/repos/kaleido/py/setup.py

Actions:
1. Clean up the recipe:
- Remove `noarch` python
- Skip `py<37`
- Add flags `--no-deps --no-build-isolation` to `script`
- Add missing `setuptools` & `wheel` to `host`
- Fix `python` in `host` and `run`
2. Skip s390x and ppc64le as kaleido-core isn't available
3. Add pip check to run_test.py
4. Remove test/imports as imports are inside run_test.py
