### PR TITLE
python-kaleido 1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,11 +49,7 @@ about:
   summary: Plotly graph export library
   description: |
     Kaleido is a cross-platform library for generating static images
-    (PNG, JPG, PDF, SVG, WebP, JSON) from Plotly figures. Version 1.x
-    is a major rewrite: instead of a bundled Chromium, it drives a
-    user-installed Google Chrome via the choreographer browser-control
-    library. Run `kaleido_get_chrome` once to download Chrome, then
-    use `kaleido.Kaleido` from Python to render figures.
+    (PNG, JPG, PDF, SVG, WebP, JSON) from Plotly figures.
   license: MIT
   license_family: MIT
   license_file: LICENSE.md

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,8 +41,14 @@ test:
     # which exits non-zero on a sterile Windows CI worker (no Chrome). Same
     # gating pattern as choreographer-feedstock (commits e8ea099, 9d1f67f).
     - kaleido_get_chrome --help  # [not win]
+    # Small smoke test: verify kaleido is importable alongside plotly and that
+    # the public surface (`Kaleido`, `write_fig`, `PageGenerator`) is reachable.
+    # We don't render here because that requires a real Chrome download — see
+    # the post-link message and `kaleido_get_chrome` for that path.
+    - python -c "import plotly.graph_objects as go; import kaleido; assert callable(kaleido.write_fig) and kaleido.Kaleido is not None and kaleido.PageGenerator is not None"
   requires:
     - pip
+    - plotly >=6.1.1
 
 about:
   home: https://github.com/plotly/kaleido

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,49 +1,66 @@
 {% set name = "python-kaleido" %}
-{% set version = "0.2.1" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido-{{ version }}.tar.gz
-  sha256: fdb673a9759835d4f455990fc1ff8919bd100a0d34f2d3de7bd5eeb2162b57ec
+  url: https://pypi.org/packages/source/k/kaleido/kaleido-{{ version }}.tar.gz
+  sha256: 5e0378a7475e98852773deeb6483dee91f8aa7b364dde7b5f2b3622cb468a3e6
 
 build:
   number: 0
-  # kaleido-core=0.2.1 isn't available on s390x or ppc64le, see https://github.com/AnacondaRecipes/kaleido-core-feedstock/blob/d512c9bd10c86d252a6dfc3f0f9057e64ff92fba/recipe/meta.yaml#L26
-  skip: true  # [linux and (s390x or ppc64le)]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<310]
+  entry_points:
+    - kaleido_mocker = kaleido.mocker:main
+    - kaleido_get_chrome = choreographer.cli._cli_utils:get_chrome_cli
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=65.0.0
     - wheel
+    - setuptools-git-versioning
   run:
     - python
-    - kaleido-core ={{ version }}
+    - choreographer >=1.3.0
+    - logistro >=1.0.8
+    - orjson >=3.10.15
+    - packaging
 
 test:
-  # imports are inside run_test.py
+  imports:
+    - kaleido
+  commands:
+    - pip check
+    - kaleido_mocker --help
+    # kaleido_get_chrome reuses choreographer.cli._cli_utils:get_chrome_cli,
+    # which exits non-zero on a sterile Windows CI worker (no Chrome). Same
+    # gating pattern as choreographer-feedstock (commits e8ea099, 9d1f67f).
+    - kaleido_get_chrome --help  # [not win]
   requires:
-    - plotly >=4.10
     - pip
 
 about:
-  home: https://github.com/plotly/Kaleido
+  home: https://github.com/plotly/kaleido
+  summary: Plotly graph export library
+  description: |
+    Kaleido is a cross-platform library for generating static images
+    (PNG, JPG, PDF, SVG, WebP, JSON) from Plotly figures. Version 1.x
+    is a major rewrite: instead of a bundled Chromium, it drives a
+    user-installed Google Chrome via the choreographer browser-control
+    library. Run `kaleido_get_chrome` once to download Chrome, then
+    use `kaleido.Kaleido` from Python to render figures.
   license: MIT
   license_family: MIT
-  license_file: LICENSE.txt
-  summary: Fast static image export for web-based visualization libraries
-  description: |
-    Python interface to Kaleido, a cross-platform library for generating static images
-    (e.g. png, svg, pdf, etc.) for web-based visualization libraries, with a
-    particular focus on eliminating external dependencies.
+  license_file: LICENSE.md
   doc_url: https://plotly.com/python/static-image-export/
-  dev_url: https://github.com/plotly/Kaleido
+  dev_url: https://github.com/plotly/kaleido
 
 extra:
   recipe-maintainers:
     - jonmmease
+    - ytausch

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,0 +1,19 @@
+@echo off
+rem Display a post-install message about Chrome being required for kaleido 1.x.
+rem Per https://docs.conda.io/projects/conda-build/en/latest/resources/link-scripts.html
+rem the contents of %PREFIX%\.messages.txt are shown after conda completes.
+rem Tracks PKG-11971.
+(
+echo.
+echo ================================ python-kaleido =================================
+echo As of version 1.0.0, kaleido requires Google Chrome to be installed.
+echo.
+echo If you already have Chrome on your system, kaleido will find it. Otherwise,
+echo install a compatible Chrome version with:
+echo.
+echo     kaleido_get_chrome
+echo.
+echo See https://github.com/plotly/kaleido for details.
+echo =================================================================================
+echo.
+) >> "%PREFIX%\.messages.txt"

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Display a post-install message about Chrome being required for kaleido 1.x.
+# Per https://docs.conda.io/projects/conda-build/en/latest/resources/link-scripts.html
+# the contents of $PREFIX/.messages.txt are shown after conda completes.
+# Tracks PKG-11971.
+cat >> "$PREFIX/.messages.txt" <<'EOF'
+
+================================ python-kaleido =================================
+As of version 1.0.0, kaleido requires Google Chrome to be installed.
+
+If you already have Chrome on your system, kaleido will find it. Otherwise,
+install a compatible Chrome version with:
+
+    kaleido_get_chrome
+
+See https://github.com/plotly/kaleido for details.
+=================================================================================
+
+EOF

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,8 +1,0 @@
-from kaleido.scopes.plotly import PlotlyScope
-import subprocess
-
-
-subprocess.run(["pip", "check"], check=True)
-
-scope = PlotlyScope()
-assert scope.transform({"data": []}).startswith(b"\x89PNG")


### PR DESCRIPTION
## python-kaleido 1.3.0

**Destination channel:** defaults

### Links
- [PKG-14570](https://anaconda.atlassian.net/browse/PKG-14570)
- [Upstream](https://github.com/plotly/kaleido)
- [PyPI](https://pypi.org/project/kaleido/1.3.0/)
- [CHANGELOG](https://github.com/plotly/kaleido/blob/v1.3.0/CHANGELOG.md)

### Explanation of changes
Major version bump: **0.2.1 (2023-07) → 1.3.0 (2026-05)**. Kaleido 1.x is a complete architecture rewrite.

[PKG-14570]: https://anaconda.atlassian.net/browse/PKG-14570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ